### PR TITLE
chore: 🤖 force renovate commits to be type of "chore"

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,5 +1,5 @@
 {
-	"extends": ["config:base", "docker:disable"],
+	"extends": ["config:base", "docker:disable", ":semanticCommitTypeAll(chore)"],
 	"packageRules": [
 		{
 			"updateTypes": ["minor", "patch"],


### PR DESCRIPTION
force renovate commits to be type of "chore"

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] UI changes have been reviewed
- [x] No UI review needed

## PR Type

What kind of change does this PR introduce?
Force the Renovate tool commits to be type of chore ONLY
<!-- Please check the one that applies to this PR using "x". -->

```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[x] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
Renovate commit messages might be of type "fix" which upgrades the repository version for no reason
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?
Force the Renovate commit messages to be only type of "chore" and not allowing to be type of fix
## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
