### PR TITLE
fix: 🐞 remove contact header from non-home-page routes

### DIFF
--- a/.ls-lint.yml
+++ b/.ls-lint.yml
@@ -17,6 +17,8 @@ ls:
     .test.tsx: PascalCase
     .scss: kebab-case
     .module.scss: PascalCase
+    .png: kebab-case
+    .jpg: kebab-case
 
 ignore:
     - _templates
@@ -28,4 +30,3 @@ ignore:
     - '@types'
     - coverage
     - node_modules
-    - public

--- a/src/components/layout/Header/Header.view.tsx
+++ b/src/components/layout/Header/Header.view.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import Link from 'next/link';
 import Image from 'next/image';
+import { useRouter } from 'next/router';
 import { useTranslation } from 'react-i18next';
 import { Link as ScrollLink } from 'react-scroll';
 
@@ -18,6 +19,7 @@ interface IProps {}
 
 const HeaderView: React.FC<IProps> = () => {
 	const { t } = useTranslation();
+	const router = useRouter();
 
 	return (
 		<div className={classes['headerContainer']} data-test-id="header">
@@ -37,9 +39,11 @@ const HeaderView: React.FC<IProps> = () => {
 							/>
 						</a>
 					</Link>
-					<ScrollLink className={classes['headerContact']} to="sellerSection" smooth>
-						{t('header.contactUs')}
-					</ScrollLink>
+					{router.pathname === '/' && (
+						<ScrollLink className={classes['headerContact']} to="sellerSection" smooth>
+							{t('header.contactUs')}
+						</ScrollLink>
+					)}
 				</div>
 				{/* <div className={classes['rightHeader']}>
 					<p className={classes['rightHeader__text']}>{t('header.rightHeaderText')}</p>


### PR DESCRIPTION
remove contact header from non-home-page routes

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] UI changes have been reviewed
- [x] No UI review needed

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

All pages have "contact us" at the header

Issue Number: N/A

## What is the new behavior?
Show this "contact us" only at home page
## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
