### PR TITLE
ci: 🚀 fix commitlint regex and remove scope from Renovate's commits

### DIFF
--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -1,5 +1,5 @@
 const commitRegex =
-	/^(chore|ci|docs|feat|fix|perf|refactor|release|style|test): ((\u00a9|\u00ae|[\u2000-\u3300]|\ud83c[\ud000-\udfff]|\ud83d[\ud000-\udfff]|\ud83e[\ud000-\udfff]) )?((\[((((?<!([A-Z]{1,10})-?)[A-Z]+-\d+)))\]) )?(([a-zA-Z0-9]+\s)*[a-zA-Z0-9]+)$/;
+	/^(chore|ci|docs|feat|fix|perf|refactor|release|style|test): ((\u00a9|\u00ae|[\u2000-\u3300]|\ud83c[\ud000-\udfff]|\ud83d[\ud000-\udfff]|\ud83e[\ud000-\udfff]) )?((\[((((?<!([A-Z]{1,10})-?)[A-Z]+-\d+)))\]) )?(([^\s]+\s)*[^\s]+)$/;
 
 module.exports = {
 	extends: ['@commitlint/config-conventional'],

--- a/renovate.json
+++ b/renovate.json
@@ -1,5 +1,5 @@
 {
-	"extends": ["config:base", ":semanticCommitTypeAll(chore)"],
+	"extends": ["config:base", ":semanticCommitTypeAll(chore)", ":semanticCommitScopeDisabled"],
 	"packageRules": [
 		{
 			"updateTypes": ["minor", "patch"],


### PR DESCRIPTION
fix commitlint regex and remove scope from Renovate's commits

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] UI changes have been reviewed
- [x] No UI review needed

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [x] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?
Renovate fails due to commitlint regex and having scope in the commit message
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?
fix the commitlint regex and remove scope from Renovate's commits
## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
